### PR TITLE
#9 [feat] contextMenu 모듈화

### DIFF
--- a/src/components/Modal/AddCategory.tsx
+++ b/src/components/Modal/AddCategory.tsx
@@ -24,7 +24,7 @@ const AddCategory = ({ closeModal }: { closeModal: () => void }) => {
   const navigate = useNavigate();
 
   const dispatch = useAppDispatch();
-  const categories = useAppSelector((state) => state.categorySlice.value);
+  const categories = useAppSelector((state) => state.category.value);
 
   return (
     <MemoModalContainer>

--- a/src/components/Modal/MemoCollection/Link/MemoCollectionLink.tsx
+++ b/src/components/Modal/MemoCollection/Link/MemoCollectionLink.tsx
@@ -21,7 +21,7 @@ const linkList = [
 const MemoCollectionLinkItem = ({ content, category }: { content: any; category?: string }) => {
   const [ogData, setOgData] = useState<OgData | null>(null);
 
-  const _category = useAppSelector((state) => state.categorySlice.value).find((e) => e.id == category);
+  const _category = useAppSelector((state) => state.category.value).find((e) => e.id == category);
 
   useEffect(() => {
     const fetchAndUpdate = async () => {

--- a/src/components/Modal/MemoCollection/MemoCollection.tsx
+++ b/src/components/Modal/MemoCollection/MemoCollection.tsx
@@ -27,7 +27,7 @@ const MemoCollection = ({ closeModal, props }: { closeModal: () => void; props: 
 
   const categories = [
     { id: null, color: '#171719', title: '전체' },
-    ...useAppSelector((state) => state.categorySlice.value),
+    ...useAppSelector((state) => state.category.value),
   ];
 
   return (

--- a/src/components/Modal/MemoCollection/Schedule/MemoCollectionSchedule.tsx
+++ b/src/components/Modal/MemoCollection/Schedule/MemoCollectionSchedule.tsx
@@ -41,7 +41,7 @@ const _dateList = Array.from({ length: 50 }, (_, i) => {
 }).sort((a: any, b: any) => a.startDate - b.startDate);
 
 const MemoCollectionSchedule = () => {
-  const categories = useAppSelector((state) => state.categorySlice.value);
+  const categories = useAppSelector((state) => state.category.value);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [date, setDate] = useState(() => {
     const date = new Date();

--- a/src/components/Modal/Search/Search.tsx
+++ b/src/components/Modal/Search/Search.tsx
@@ -84,8 +84,8 @@ const SearchResultItem = ({
 const Search = ({ closeModal }: { closeModal: () => void }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
-  const categories = useAppSelector((state) => state.categorySlice.value);
-  const memos = useAppSelector((state) => state.memoSlice.value);
+  const categories = useAppSelector((state) => state.category.value);
+  const memos = useAppSelector((state) => state.memo.value);
 
   const filteredMemos = memos.filter((memo) => {
     if (getSearchableText(memo) === null) return false; // 추후 null 처리 삭제

--- a/src/components/SideBar/SideMessage/ContextMenu/ContextMenu.tsx
+++ b/src/components/SideBar/SideMessage/ContextMenu/ContextMenu.tsx
@@ -1,29 +1,73 @@
-import { forwardRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '@stores/config/configStore';
 import { ContextMenuWrapper, ContextMenuHeader, ContextMenuTitle, ContextMenuItem, Divider } from './ContextMenu.Style';
 import { Dot } from '../SideMessage.Style';
+import { closeContextMenu } from '@stores/modules/contextMenuSlice';
+import { useEffect, useRef } from 'react';
 
-interface Props {
-  anchor: { x: number; y: number };
-  title: string;
-  color: string;
-  onPin: () => void;
-  onCategory: () => void;
-  onDelete: () => void;
-}
+const ContextMenu = () => {
+  const dispatch = useDispatch();
+  const { isOpen, anchor, props } = useSelector((state: RootState) => state.contextMenu);
 
-const ContextMenu = forwardRef<HTMLDivElement, Props>(({ anchor, title, color, onPin, onCategory, onDelete }, ref) => {
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        dispatch(closeContextMenu());
+      }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
+        dispatch(closeContextMenu());
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [dispatch]);
+
+  if (!isOpen || !anchor || !props) return null;
+
   return (
-    <ContextMenuWrapper ref={ref} style={{ top: anchor.y, left: anchor.x }}>
+    <ContextMenuWrapper ref={contextMenuRef} style={{ top: anchor.y, left: anchor.x }}>
       <ContextMenuHeader>
-        <Dot style={{ backgroundColor: color }} />
-        <ContextMenuTitle>{title}</ContextMenuTitle>
+        <Dot style={{ backgroundColor: props.color }} />
+        <ContextMenuTitle>{props.title}</ContextMenuTitle>
       </ContextMenuHeader>
       <Divider />
-      <ContextMenuItem onClick={onPin}>즐겨찾기</ContextMenuItem>
-      <ContextMenuItem onClick={onCategory}>카테고리 설정</ContextMenuItem>
-      <ContextMenuItem onClick={onDelete}>삭제</ContextMenuItem>
+      <ContextMenuItem
+        onClick={() => {
+          props.onPin();
+          dispatch(closeContextMenu());
+        }}
+      >
+        즐겨찾기
+      </ContextMenuItem>
+      <ContextMenuItem
+        onClick={() => {
+          props.onCategory();
+          dispatch(closeContextMenu());
+        }}
+      >
+        카테고리 설정
+      </ContextMenuItem>
+      <ContextMenuItem
+        onClick={() => {
+          props.onDelete();
+          dispatch(closeContextMenu());
+        }}
+      >
+        삭제
+      </ContextMenuItem>
     </ContextMenuWrapper>
   );
-});
+};
 
 export default ContextMenu;

--- a/src/controllers/api.ts
+++ b/src/controllers/api.ts
@@ -99,9 +99,9 @@ const fetchCategory = async (username: string) => {
       id: category.categoryId,
       title: category.categoryName,
       pinned: false,
-      color: category.categoryColor.replace(/^color/, '') || '#000000',
-      content: category.chatItems?.[0]?.data ?? 'empty',
-      lastDate: new Date(category.chatItems?.[0]?.timestamp ?? Date.now()),
+      color: category.categoryColor.replace(/^color/, ''),
+      content: category.chatItems[0].data,
+      lastDate: new Date(category.chatItems[0].timestamp),
     }))
     .sort((a, b) => b.lastDate.getTime() - a.lastDate.getTime());
 

--- a/src/hooks/useContextMenu.tsx
+++ b/src/hooks/useContextMenu.tsx
@@ -1,0 +1,29 @@
+// utils/hooks/useContextMenuHandler.ts
+import { useRef } from 'react';
+import { useAppDispatch } from '@hooks/useRedux';
+import { openContextMenu } from '@stores/modules/contextMenuSlice';
+
+export const useContextMenuHandler = (menuProps: any) => {
+  const dispatch = useAppDispatch();
+  const touchTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  const triggerContextMenu = (x: number, y: number) => {
+    dispatch(openContextMenu({ anchor: { x, y }, props: menuProps }));
+  };
+
+  const handleContextMenu = (e: React.MouseEvent | React.TouchEvent) => {
+    e.preventDefault();
+    const { clientX, clientY } = 'touches' in e ? e.touches[0] : e;
+    triggerContextMenu(clientX, clientY);
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchTimeout.current = setTimeout(() => handleContextMenu(e), 600);
+  };
+
+  const clearTouchTimeout = () => {
+    if (touchTimeout.current) clearTimeout(touchTimeout.current);
+  };
+
+  return { handleContextMenu, handleTouchStart, clearTouchTimeout };
+};

--- a/src/layout/Header/Header.tsx
+++ b/src/layout/Header/Header.tsx
@@ -12,7 +12,7 @@ import { useEffect, useRef } from 'react';
 const Header = ({ activeMenu, closeMenu }: { activeMenu: () => void; closeMenu: () => void }) => {
   const [searchParams] = useSearchParams();
   const categoryId = searchParams.get('category');
-  const categories = useAppSelector((state) => state.categorySlice.value);
+  const categories = useAppSelector((state) => state.category.value);
   const category = categories.find((e) => e.id == categoryId);
   const modalRef = useRef<HTMLDivElement>(null);
 

--- a/src/layout/SideBar/SideBar.tsx
+++ b/src/layout/SideBar/SideBar.tsx
@@ -44,7 +44,7 @@ const SideBar = ({ toggleMenu, closeMenu }: { toggleMenu: boolean; closeMenu: ()
     modalProps,
   );
 
-  const categories = useAppSelector((state) => state.categorySlice.value);
+  const categories = useAppSelector((state) => state.category.value);
   const onWholeMemoClick = () => {
     setSearchParams({});
   };

--- a/src/pages/Home/page.tsx
+++ b/src/pages/Home/page.tsx
@@ -12,7 +12,7 @@ const HomePage = () => {
   }
   const dispatch = useAppDispatch();
 
-  const count = useAppSelector((state) => state.counterSlice.value);
+  const count = useAppSelector((state) => state.counter.value);
 
   return (
     <div>

--- a/src/pages/Memo/page.tsx
+++ b/src/pages/Memo/page.tsx
@@ -31,11 +31,11 @@ import { shallowEqual } from 'react-redux';
 const MemoList = ({ category }: { category: string | null }) => {
   const memoListContainerRef = useRef<HTMLDivElement>(null);
 
-  const categories = useAppSelector((state) => state.categorySlice.value);
+  const categories = useAppSelector((state) => state.category.value);
 
   const memos = useAppSelector(
     (state) =>
-      state.memoSlice.value.filter((e) => {
+      state.memo.value.filter((e) => {
         if (!category) return true;
         return category === e.categoryId;
       }),

--- a/src/stores/config/configStore.ts
+++ b/src/stores/config/configStore.ts
@@ -1,29 +1,22 @@
-//configStore.ts
 import { configureStore } from '@reduxjs/toolkit';
-import modalToggle from '../modules/todoSlice';
-import counterSlice from '../modules/counterSlice';
-import categorySlice from '@stores/modules/category';
-import memoSlice from '@stores/modules/memo';
+import modalToggle from '@stores/modules/todoSlice';
+import counter from '@stores/modules/counterSlice';
+import category from '@stores/modules/category';
+import memo from '@stores/modules/memo';
+import contextMenu from '@stores/modules/contextMenuSlice';
 
-//1. configureStore 함수를 사용하여 store를 생성
-//2. configureStore 함수의 인자로는 reducer 속성이 포함된 객체(module)가 전달
 const store = configureStore({
   reducer: {
-    modalToggle,
-    counterSlice,
-    categorySlice,
-    memoSlice,
+    modal: modalToggle,
+    counter,
+    category,
+    memo,
+    contextMenu,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware({ serializableCheck: false }),
 });
 
-//스토어의 전체 상태 타입을 RootState 타입으로 정의
-//ReturnType<typeof store.getState>: 스토어의 getState 메서드의 반환값을 나타낸다.
 export type RootState = ReturnType<typeof store.getState>;
-
-// 스토어의 디스패치 함수 타입을 AppDispatch 타입으로 정의
-// typeof store.dispatch: 스토어의 dispatch 메서드의 타입을 나타낸다.
 export type AppDispatch = typeof store.dispatch;
 
-//최상위 컴포넌트에 제공할 store
 export default store;

--- a/src/stores/modules/category.ts
+++ b/src/stores/modules/category.ts
@@ -67,7 +67,7 @@ export const categorySlice = createSlice({
 export const { addCategory, editCategory, deleteCategory, togglePin } = categorySlice.actions;
 
 // slice의 상태값
-export const categoryState = (state: RootState) => state.categorySlice.value;
+export const categoryState = (state: RootState) => state.category.value;
 
 //slice의 reducers
 export default categorySlice.reducer;

--- a/src/stores/modules/contextMenuSlice.ts
+++ b/src/stores/modules/contextMenuSlice.ts
@@ -1,0 +1,45 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface ContextMenuState {
+  isOpen: boolean;
+  anchor: { x: number; y: number } | null;
+  props: {
+    title: string;
+    color: string;
+    onPin: () => void;
+    onCategory: () => void;
+    onDelete: () => void;
+  } | null;
+}
+
+const initialState: ContextMenuState = {
+  isOpen: false,
+  anchor: null,
+  props: null,
+};
+
+const contextMenuSlice = createSlice({
+  name: 'contextMenu',
+  initialState,
+  reducers: {
+    openContextMenu: (
+      state,
+      action: PayloadAction<{
+        anchor: { x: number; y: number };
+        props: ContextMenuState['props'];
+      }>,
+    ) => {
+      state.isOpen = true;
+      state.anchor = action.payload.anchor;
+      state.props = action.payload.props;
+    },
+    closeContextMenu: (state) => {
+      state.isOpen = false;
+      state.anchor = null;
+      state.props = null;
+    },
+  },
+});
+
+export const { openContextMenu, closeContextMenu } = contextMenuSlice.actions;
+export default contextMenuSlice.reducer;

--- a/src/stores/modules/counterSlice.ts
+++ b/src/stores/modules/counterSlice.ts
@@ -28,6 +28,6 @@ export const counterSlice = createSlice({
 export const { increment, decrement } = counterSlice.actions;
 
 // slice의 상태값
-export const counterState = (state: RootState) => state.modalToggle.value;
+export const counterState = (state: RootState) => state.modal.value;
 
 export default counterSlice.reducer;

--- a/src/stores/modules/memo.ts
+++ b/src/stores/modules/memo.ts
@@ -49,7 +49,7 @@ export const memoSlice = createSlice({
 export const { addMemos } = memoSlice.actions;
 
 // slice의 상태값
-export const categoryState = (state: RootState) => state.memoSlice.value;
+export const categoryState = (state: RootState) => state.memo.value;
 
 // slice의 reducers
 export default memoSlice.reducer;

--- a/src/stores/modules/todoSlice.ts
+++ b/src/stores/modules/todoSlice.ts
@@ -27,7 +27,7 @@ export const toggleSlice = createSlice({
 export const { modalToggleAction } = toggleSlice.actions;
 
 // slice의 상태값
-export const modalState = (state: RootState) => state.modalToggle.value;
+export const modalState = (state: RootState) => state.modal.value;
 
 //slice의 reducers
 export default toggleSlice.reducer;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feat/#9 -> dev

### 작업 내용

추후 main-component에서 재사용가능하도록 redux 및 커스텀훅(핸들러) 모듈화함.
- props만 건들면 될듯함니다.

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다.
결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

- [x] 정상 작동!

### 리뷰 요구사항

ex) 메인 페이지 중점으로 QA 진행 부탁드립니다.
